### PR TITLE
gitignoreSource: ensure Nix store path determinism

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -4,5 +4,10 @@ let
 in
 {
   inherit (find-files) gitignoreFilter;
-  gitignoreSource = p: lib.cleanSourceWith { filter = find-files.gitignoreFilter p; src = p; };
+  
+  gitignoreSource = path: builtins.path {
+    name = "source";
+    filter = find-files.gitignoreFilter path;
+    inherit path;
+  };
 }


### PR DESCRIPTION
This ensures that, when used in situations like `gitignoreSource ./.`, both Hydra and local checkout will have the exact same Nix path, which is important for reproducibility and being able to leverage binary cache.