### PR TITLE
Remove cleanSourceWith from features list

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,6 @@ mkDerivation {
  - Reads parent gitignores even if only pointed at a subdirectory
  - Source hashes only change when output changes
  - Not impacted by large or inaccessible ignored directories
- - Composes with `cleanSourceWith`
  - Reads user git configuration; no need to bother your team with your tool config.
  - Also works with restrict-eval enabled (if avoiding `fetchFromGitHub`)
  - No import from derivation ("IFD")


### PR DESCRIPTION
`gitignoreSource` does not compose with `cleanSourceWith` as of 6e7569637d699facfdcde91ab5c94bac06d39edc.

See discussion in #11. Another way to resolve this is to make `cleanSourceWith` compose one way only, with `gitignoreSource` always having to be the final filter (based on @yorickVP's workaround):

```nix
{ lib ? import <nixpkgs/lib> }:
let
  find-files = import ./find-files.nix { inherit lib; };

  constantSource = path:
    if path ? _isLibCleanSourceWith
    then builtins.path {
      name = "source";
      inherit (path) filter;
      path = path.origSrc;
    }
    else builtins.path {
      name = "source";
      inherit path;
    };
in
{
  inherit (find-files) gitignoreFilter;

  gitignoreSource = path:
    constantSource (lib.cleanSourceWith {
      filter = find-files.gitignoreFilter path;
      src = path;
    });
}
```

The problem with this is that it's not intuitive and still results in API breakage, while there are other ways to compose filters that are more explicit and work with deterministic source names.
